### PR TITLE
Removed the default namespace and tf_prefix

### DIFF
--- a/dynaarm_single_example/dynaarm_single_example/launch/mock.launch.py
+++ b/dynaarm_single_example/dynaarm_single_example/launch/mock.launch.py
@@ -97,7 +97,7 @@ def generate_launch_description():
     declared_arguments = [
         DeclareLaunchArgument(
             name="namespace",
-            default_value="dynaarm1",
+            default_value="",
         ),
     ]
 

--- a/dynaarm_single_example/dynaarm_single_example/launch/real.launch.py
+++ b/dynaarm_single_example/dynaarm_single_example/launch/real.launch.py
@@ -113,7 +113,7 @@ def generate_launch_description():
     declared_arguments = [
         DeclareLaunchArgument(
             name="namespace",
-            default_value="dynaarm1",
+            default_value="",
         ),
     ]
 

--- a/dynaarm_single_example/dynaarm_single_example/launch/sim.launch.py
+++ b/dynaarm_single_example/dynaarm_single_example/launch/sim.launch.py
@@ -108,7 +108,7 @@ def generate_launch_description():
     declared_arguments = [
         DeclareLaunchArgument(
             name="namespace",
-            default_value="dynaarm1",
+            default_value="",
         ),
         DeclareLaunchArgument("world", default_value="duatic_empty", description="World name"),
     ]


### PR DESCRIPTION
This is not necessary when launching only one DynaArm. This just adds some unnecessary complexity.